### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/kaitai/Cargo.toml
+++ b/kaitai/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Klim Tsoutsman <klimusha@gmail.com>"]
 edition = "2018"
 description = "A macro for compiling Kaitai Struct into Rust."
 readme = true
-repository = "https://www.github.com/tsoutsman/kaitai-rs"
+repository = "https://github.com/tsoutsman/kaitai-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["binary", "cross-platform", "ks", "ksy", "ksc"]
 # The last 3 categories refer to Kaitai Struct itself. I think it's fair to put them here as this


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96